### PR TITLE
Update Coffee and Coding

### DIFF
--- a/04-Coffee-and-Coding.Rmd
+++ b/04-Coffee-and-Coding.Rmd
@@ -17,19 +17,17 @@ The format is generally 30–40 minutes for a presentation, followed by time for
 
 Where possible, Coffee and Coding presentations are recorded to allow people to catch up on talks they may have missed and to provide a useful training resource for colleagues.
 
-These recordings are available on the [Coffee and Coding Microsoft Stream Channel](https://web.microsoftstream.com/channel/f6aa6c5d-e90c-44b7-8ccc-28a318fa0630). We regularly update the access list, but if you cannot access the videos please contact the Coffee and Coding mailbox.
+These recordings are available on the [Coffee and Coding Sharepoint page](https://justiceuk.sharepoint.com/:u:/r/sites/MoJCoffee%26Coding/SitePages/Coffee-and-Coding-videos.aspx?csf=1&web=1&e=76lQrX). We regularly update the access list, but if you cannot access the videos please contact the Coffee and Coding mailbox.
 
 ### Some useful talks
 
 If you are new to coding in MoJ, you might find the following recorded talks useful:-
 
-* [An Introduction to GitHub](https://web.microsoftstream.com/video/fa7c803c-129c-4b0d-bedf-7dd8edeef333?channelId=f6aa6c5d-e90c-44b7-8ccc-28a318fa0630)
+* [Ten top tips for data presentation](https://justiceuk.sharepoint.com/:v:/r/sites/MoJCoffee%26Coding/Shared%20Documents/Coffee%20%26%20Coding/Recordings/Featured%20recordings/Coffee%20and%20Coding%20-%20Ten%20Top%20Tips%20for%20Data%20Presentation-20220511_023049.mp4?csf=1&web=1&e=ahCb6I)
 
-* [Ten Top Tips for Data Presentation](https://web.microsoftstream.com/video/393d138f-bb4d-449f-a707-fe122e8e7aa0)
+* [Package management in renv](https://justiceuk.sharepoint.com/:v:/r/sites/MoJCoffee%26Coding/Shared%20Documents/Coffee%20%26%20Coding/Recordings/Featured%20recordings/Coffee%20and%20Coding%20-%20Introduction%20to%20renv%20package%20management-20220504_112130.mp4?csf=1&web=1&e=Vsi4G7)
 
-* [An Introduction to Airflow 2.0](https://web.microsoftstream.com/video/712b49b7-8995-4802-95de-c813c8b213bc)
-
-* [Package Management in renv](https://web.microsoftstream.com/video/3ec54ac3-473c-4268-9d54-9f7096338824)
+* [Developing an Aacessible and gov.uk styled dashboard](https://justiceuk.sharepoint.com/:v:/r/sites/MoJCoffee%26Coding/Shared%20Documents/Coffee%20%26%20Coding/Recordings/Featured%20recordings/MoJ%20Coffee%20%26%20Coding%20-%20developing%20an%20accessible%20and%20gov%20uk%20styled%20dashboard%2010-08-23-20230811_094938.mov?csf=1&web=1&e=0OYR2K)
 
 The full catalogue of recorded talks can be found [here](https://web.microsoftstream.com/channel/f6aa6c5d-e90c-44b7-8ccc-28a318fa0630).
 

--- a/04-Coffee-and-Coding.Rmd
+++ b/04-Coffee-and-Coding.Rmd
@@ -27,9 +27,9 @@ If you are new to coding in MoJ, you might find the following recorded talks use
 
 * [Package management in renv](https://justiceuk.sharepoint.com/:v:/r/sites/MoJCoffee%26Coding/Shared%20Documents/Coffee%20%26%20Coding/Recordings/Featured%20recordings/Coffee%20and%20Coding%20-%20Introduction%20to%20renv%20package%20management-20220504_112130.mp4?csf=1&web=1&e=Vsi4G7)
 
-* [Developing an Aacessible and gov.uk styled dashboard](https://justiceuk.sharepoint.com/:v:/r/sites/MoJCoffee%26Coding/Shared%20Documents/Coffee%20%26%20Coding/Recordings/Featured%20recordings/MoJ%20Coffee%20%26%20Coding%20-%20developing%20an%20accessible%20and%20gov%20uk%20styled%20dashboard%2010-08-23-20230811_094938.mov?csf=1&web=1&e=0OYR2K)
+* [Developing an Accessible and gov.uk styled dashboard](https://justiceuk.sharepoint.com/:v:/r/sites/MoJCoffee%26Coding/Shared%20Documents/Coffee%20%26%20Coding/Recordings/Featured%20recordings/MoJ%20Coffee%20%26%20Coding%20-%20developing%20an%20accessible%20and%20gov%20uk%20styled%20dashboard%2010-08-23-20230811_094938.mov?csf=1&web=1&e=0OYR2K)
 
-The full catalogue of recorded talks can be found [here](https://web.microsoftstream.com/channel/f6aa6c5d-e90c-44b7-8ccc-28a318fa0630).
+The full archive of recorded talks can be found [here](https://justiceuk.sharepoint.com/sites/MoJCoffee&Coding/_layouts/15/SeeAll.aspx?Page=%2Fsites%2FMoJCoffee%26Coding%2FSitePages%2FCoffee-and-Coding-videos.aspx&InstanceId=caf0b097-6250-43a4-bb89-9e4cae7f841e).
 
 ## Code repositories
 


### PR DESCRIPTION
Updating the links to C&C recordings to the new Sharepoint page as Microsoft Stream is now defunct.

Updating the useful videos selection to be more current (Airflow no longer really being used, GitHub intro replaced with specific training).