### PR TITLE
Adding section on learning pathways

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -54,6 +54,18 @@ The Data and Analysis bite-sized sessions are short sessions (generally talks of
 You can find recordings of bite-sized sessions in the [bite-sized session video library](https://justiceuk.sharepoint.com/:u:/r/sites/DataandAnalysisBitesizesessions/SitePages/video_collections.aspx?csf=1&web=1&share=EQrAJNYopYNItmLPYNdOZOQBuDPFJjYWtaBPdgUH9J0Uqg&e=3Wsa1s). 
 For more information including if you are interested in presenting a session or joining the bite-sized session facilitation team please contact Aidan Mews or Edward Adams.
 
+## Learning Pathways
+
+Learning Pathways are a structured series of learning activities and resources designed to help individuals acquire specific skills and knowledge.
+
+The [Introduction to Data Science Learning Pathway](https://app.datacamp.com/learn/custom-tracks/custom-introduction-to-data-science-in-dedsai-python) has been developed to equip staff with the foundational knowledge and skills they need to make a successful start as a Data Scientist. (More pathways are under development.)
+
+Who is it for?
+- Everyone with an interest in upskilling in Data Science! The Pathway was developed with new HEOs in mind but would also suit other grades seeking a refresher or those transitioning from another profession.
+- Python users. (A version for R users is under development.)
+
+The Pathway can be accessed through DataCamp (see the [DataCamp](#DataCamp) section for more information).
+
 ## Analytical Function training
 There are many Analytical Function training opportunities for analysts including about specialist topics not presently covered internally. Examples useful for Reproducible Analytical Pipeline practitioners include [Best practice in programming – clean code](https://analysisfunction.civilservice.gov.uk/training/best-practice-in-programming-clean-code/) and a more lengthy [Introduction to unit testing](https://analysisfunction.civilservice.gov.uk/training/introduction-to-unit-testing/) than currently available internally. You can learn more about such opportunities via:
 


### PR DESCRIPTION
I’ve added a new section on Learning Pathways and linked to the newly developed Intro to Data Science Pathway, along with some information on who it is for.

I chose to make a new section for this rather than, say, adding under the DataCamp section because even though the pathway is hosted on DataCamp, it contains resources other than DataCamp courses. Plus, new pathways will be developed in future so I think it makes sense for it to have it's own section. Happy to be challenges on this :)

I also chose to add the new section before 'Analytical Function training' because the pathway comes under internal training.

Suggestions for changes or updates welcome :)